### PR TITLE
[13] Fix performance issue with insert Room DB logic

### DIFF
--- a/app/src/main/java/com/example/surveysapp/repository/SurveyRepository.kt
+++ b/app/src/main/java/com/example/surveysapp/repository/SurveyRepository.kt
@@ -39,7 +39,7 @@ class SurveyRepository @Inject constructor(
      * @return List<IssueEntity>
      */
     suspend fun getLocalSurveys(): List<SurveyRoomEntity> {
-        return surveyDao.getAllIssues()
+        return surveyDao.getAllSurveys()
     }
 
     /**
@@ -47,7 +47,7 @@ class SurveyRepository @Inject constructor(
      * @param issues
      */
     suspend fun insertSurveys(issues: List<SurveyRoomEntity?>?) {
-        return surveyDao.insertAllIssues(issues)
+        return surveyDao.insertSurveys(issues)
     }
 
     /**

--- a/app/src/main/java/com/example/surveysapp/room/SurveyDao.kt
+++ b/app/src/main/java/com/example/surveysapp/room/SurveyDao.kt
@@ -1,9 +1,6 @@
 package com.example.surveysapp.room
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room.*
 
 /**
  * @author longtran
@@ -11,11 +8,25 @@ import androidx.room.Query
  */
 @Dao
 interface SurveyDao {
+
     @Query("SELECT * FROM ${SurveyRoomEntity.TABLE_NAME}")
-    suspend fun getAllIssues(): List<SurveyRoomEntity>
+    suspend fun getAllSurveys(): List<SurveyRoomEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertAllIssues(surveys: List<SurveyRoomEntity?>?)
+    suspend fun insertAllSurveys(surveys: List<SurveyRoomEntity?>?)
+
+    @Query("SELECT * FROM ${SurveyRoomEntity.TABLE_NAME} LIMIT 1")
+    suspend fun getSurvey(): SurveyRoomEntity?
+
+    @Transaction
+    suspend fun insertSurveys(surveys: List<SurveyRoomEntity?>?, isLoadMore: Boolean = false){
+        // If table is empty or loading more data then don't need to clear the table
+        if (getSurvey() != null && !isLoadMore) {
+            removeAll()
+        }
+
+        insertAllSurveys(surveys)
+    }
 
     @Query("DELETE FROM ${SurveyRoomEntity.TABLE_NAME}")
     suspend fun removeAll()

--- a/app/src/main/java/com/example/surveysapp/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/surveysapp/viewModel/HomeViewModel.kt
@@ -99,10 +99,6 @@ class HomeViewModel @Inject constructor(
     }
 
     private suspend fun updateToRoom(responseData: List<Survey>) {
-        if (surveyRepository.getLocalSurveys().isNotEmpty()) {
-            surveyRepository.removeSurveys()
-        }
-
         surveyRepository.insertSurveys(responseData.toRoomEntityList())
     }
 


### PR DESCRIPTION
#13 

## **What happened 👀**

- `getLocalSurveys.isNotEmpty()` is not good for performance while the time complexity increases due to the large of data source

## **Insight 📝**

- Created a `@Query` to get 1 item is enough to know table is empty or not
- Created a `@Transaction` to wrap the insert logic