### PR TITLE
[9] Some issues on Network layer

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -53,6 +53,7 @@
 # Application classes that will be serialized/deserialized over Gson
 -keep class com.google.gson.examples.android.model.** { *; }
 -keep class com.example.surveysapp.entity.** { *; }
+-keep class com.example.surveysapp.request.** { *; }
 
 # Coroutines
 # ServiceLoader support

--- a/app/src/main/java/com/example/surveysapp/api/NonAuthApiService.kt
+++ b/app/src/main/java/com/example/surveysapp/api/NonAuthApiService.kt
@@ -1,15 +1,15 @@
 package com.example.surveysapp.api
 
-import com.example.surveysapp.BuildConfig
 import com.example.surveysapp.entity.AuthEntity
 import com.example.surveysapp.entity.BaseEntity
-import com.example.surveysapp.other.ApiKey
+import com.example.surveysapp.request.ForgotPasswordRequest
+import com.example.surveysapp.request.LoginRequest
+import com.example.surveysapp.request.LogoutRequest
+import com.example.surveysapp.request.RefreshTokenRequest
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.Body
-import retrofit2.http.Field
-import retrofit2.http.FormUrlEncoded
 import retrofit2.http.POST
 
 /**
@@ -17,33 +17,15 @@ import retrofit2.http.POST
  * @since 13/06/2021
  */
 interface NonAuthApiService {
-    @FormUrlEncoded
     @POST("api/v1/oauth/token")
-    suspend fun login(
-        @Field(ApiKey.EMAIL) email: String,
-        @Field(ApiKey.PASSWORD) password: String,
-        @Field(ApiKey.GRANT_TYPE) grantType: String? = "password",
-        @Field(ApiKey.CLIENT_ID) clientId: String? = BuildConfig.client_id,
-        @Field(ApiKey.CLIENT_SECRET) clientSecret: String? = BuildConfig.client_secret
-    ): Response<BaseEntity<AuthEntity>>
+    suspend fun login(@Body body: LoginRequest): Response<BaseEntity<AuthEntity>>
 
-    @FormUrlEncoded
     @POST("api/v1/oauth/token")
-    fun refreshToken(
-        @Field(ApiKey.REFRESH_TOKEN) refreshToken: String,
-        @Field(ApiKey.GRANT_TYPE) grantType: String? = "refresh_token",
-        @Field(ApiKey.CLIENT_ID) clientId: String? = BuildConfig.client_id,
-        @Field(ApiKey.CLIENT_SECRET) clientSecret: String? = BuildConfig.client_secret
-    ): Call<BaseEntity<AuthEntity>>
+    fun refreshToken(@Body body: RefreshTokenRequest): Call<BaseEntity<AuthEntity>>
 
-    @FormUrlEncoded
     @POST("api/v1/oauth/revoke")
-    suspend fun logout(
-        @Field(ApiKey.TOKEN) accessToken: String,
-        @Field(ApiKey.CLIENT_ID) clientId: String? = BuildConfig.client_id,
-        @Field(ApiKey.CLIENT_SECRET) clientSecret: String? = BuildConfig.client_secret
-    ): Response<ResponseBody>
+    suspend fun logout(@Body body: LogoutRequest): Response<ResponseBody>
 
     @POST("api/v1/passwords")
-    suspend fun forgotPassword(@Body params: HashMap<String, Any>): Response<ResponseBody>
+    suspend fun forgotPassword(@Body body: ForgotPasswordRequest): Response<ResponseBody>
 }

--- a/app/src/main/java/com/example/surveysapp/api/TokenAuthenticator.kt
+++ b/app/src/main/java/com/example/surveysapp/api/TokenAuthenticator.kt
@@ -3,6 +3,7 @@ package com.example.surveysapp.api
 import com.example.surveysapp.SharedPreferencesManager
 import com.example.surveysapp.entity.toModel
 import com.example.surveysapp.other.Constant
+import com.example.surveysapp.request.RefreshTokenRequest
 import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
@@ -30,7 +31,7 @@ class TokenAuthenticator @Inject constructor(
         }
 
         val result =
-            nonAuthApiService.refreshToken(sharedPreferencesManager.getRefreshToken()).execute()
+            nonAuthApiService.refreshToken(RefreshTokenRequest(sharedPreferencesManager.getRefreshToken())).execute()
 
         return if (result.isSuccessful) {
             // refresh token is successful, we saved new token to storage.

--- a/app/src/main/java/com/example/surveysapp/api/TokenInterceptor.kt
+++ b/app/src/main/java/com/example/surveysapp/api/TokenInterceptor.kt
@@ -3,6 +3,7 @@ package com.example.surveysapp.api
 import com.example.surveysapp.SharedPreferencesManager
 import com.example.surveysapp.entity.toModel
 import com.example.surveysapp.other.Constant
+import com.example.surveysapp.request.RefreshTokenRequest
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.util.*
@@ -37,7 +38,7 @@ class TokenInterceptor @Inject constructor(
 
             if (compareDateResult == -1) { // Token has expired
                 val result =
-                    nonAuthApiService.refreshToken(sharedPreferencesManager.getRefreshToken())
+                    nonAuthApiService.refreshToken(RefreshTokenRequest(sharedPreferencesManager.getRefreshToken()))
                         .execute()
                 if (result.isSuccessful) {
                     // refresh token is successful, we saved new token to storage.

--- a/app/src/main/java/com/example/surveysapp/entity/BaseEntity.kt
+++ b/app/src/main/java/com/example/surveysapp/entity/BaseEntity.kt
@@ -1,6 +1,9 @@
 package com.example.surveysapp.entity
 
+import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import okhttp3.ResponseBody
+import retrofit2.Response
 
 /**
  * @author longtran
@@ -16,3 +19,24 @@ data class BaseException(
     @SerializedName("errors")
     val errors: List<ErrorEntity>? = null
 )
+
+/**
+ * Extensions convert from retrofit Response to BaseEntity model
+ */
+fun <T> Response<BaseEntity<T>>.result(): BaseEntity<T> = if (isSuccessful) {
+    body()!!
+} else {
+    // Convert errorBody to ErrorEntity for shorter access
+    val baseException =
+        Gson().fromJson(errorBody()?.string(), BaseException::class.java)
+    BaseEntity(null, baseException.errors?.get(0))
+}
+
+fun Response<ResponseBody>.resultBoolean(): BaseEntity<Boolean> = if (isSuccessful) {
+    BaseEntity(true, null)
+} else {
+    // Convert errorBody to ErrorEntity for shorter access
+    val baseException =
+        Gson().fromJson(errorBody()?.string(), BaseException::class.java)
+    BaseEntity(null, baseException.errors?.get(0))
+}

--- a/app/src/main/java/com/example/surveysapp/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/surveysapp/repository/AuthRepository.kt
@@ -1,13 +1,15 @@
 package com.example.surveysapp.repository
 
-import com.example.surveysapp.BuildConfig
 import com.example.surveysapp.SharedPreferencesManager
 import com.example.surveysapp.api.NonAuthApiService
 import com.example.surveysapp.entity.AuthEntity
 import com.example.surveysapp.entity.BaseEntity
-import com.example.surveysapp.entity.BaseException
-import com.example.surveysapp.other.ApiKey
-import com.google.gson.Gson
+import com.example.surveysapp.entity.result
+import com.example.surveysapp.entity.resultBoolean
+import com.example.surveysapp.request.ForgotPasswordRequest
+import com.example.surveysapp.request.LoginRequest
+import com.example.surveysapp.request.LogoutRequest
+import com.example.surveysapp.request.UserRequest
 import javax.inject.Inject
 
 /**
@@ -19,49 +21,16 @@ class AuthRepository @Inject constructor(
     private val sharedPreferencesManager: SharedPreferencesManager
 ) {
     suspend fun login(email: String, password: String): BaseEntity<AuthEntity> {
-        val response = nonAuthApiService.login(email = email, password = password)
-
-        return if (response.isSuccessful) {
-            response.body()!!
-        } else {
-            // Convert errorBody to ErrorEntity for shorter access
-            val baseException =
-                Gson().fromJson(response.errorBody()?.string(), BaseException::class.java)
-            BaseEntity(null, baseException.errors?.get(0))
-        }
+        return nonAuthApiService.login(LoginRequest(email, password)).result()
     }
 
     suspend fun logout(): BaseEntity<Boolean> {
-        val response = nonAuthApiService.logout(sharedPreferencesManager.getAccessToken())
-
-        return if (response.isSuccessful) {
-            BaseEntity(true, null)
-        } else {
-            // Convert errorBody to ErrorEntity for shorter access
-            val baseException =
-                Gson().fromJson(response.errorBody()?.string(), BaseException::class.java)
-            BaseEntity(null, baseException.errors?.get(0))
-        }
+        return nonAuthApiService.logout(LogoutRequest(sharedPreferencesManager.getAccessToken()))
+            .resultBoolean()
     }
 
     suspend fun forgotPassword(email: String): BaseEntity<Boolean> {
-        // Create params structure
-        val params = HashMap<String, Any>()
-        params[ApiKey.USER] = HashMap<String, String>().apply {
-            put(ApiKey.EMAIL, email)
-        }
-        params[ApiKey.CLIENT_ID] = BuildConfig.client_id
-        params[ApiKey.CLIENT_SECRET] = BuildConfig.client_secret
-
-        val response = nonAuthApiService.forgotPassword(params)
-
-        return if (response.isSuccessful) {
-            BaseEntity(true, null)
-        } else {
-            // Convert errorBody to ErrorEntity for shorter access
-            val baseException =
-                Gson().fromJson(response.errorBody()?.string(), BaseException::class.java)
-            BaseEntity(null, baseException.errors?.get(0))
-        }
+        return nonAuthApiService.forgotPassword(ForgotPasswordRequest(UserRequest(email)))
+            .resultBoolean()
     }
 }

--- a/app/src/main/java/com/example/surveysapp/repository/ProfileRepository.kt
+++ b/app/src/main/java/com/example/surveysapp/repository/ProfileRepository.kt
@@ -2,9 +2,8 @@ package com.example.surveysapp.repository
 
 import com.example.surveysapp.api.AuthApiService
 import com.example.surveysapp.entity.BaseEntity
-import com.example.surveysapp.entity.BaseException
 import com.example.surveysapp.entity.ProfileWrapperEntity
-import com.google.gson.Gson
+import com.example.surveysapp.entity.result
 import javax.inject.Inject
 
 /**
@@ -15,14 +14,6 @@ class ProfileRepository @Inject constructor(
     private val authApiService: AuthApiService
 ) {
     suspend fun getProfile(): BaseEntity<ProfileWrapperEntity> {
-        val response = authApiService.getProfile()
-
-        return if (response.isSuccessful) {
-            response.body()!!
-        } else {
-            // Convert errorBody to ErrorEntity for shorter access
-            val baseException = Gson().fromJson(response.errorBody()?.string(), BaseException::class.java)
-            BaseEntity(null, baseException.errors?.get(0))
-        }
+        return authApiService.getProfile().result()
     }
 }

--- a/app/src/main/java/com/example/surveysapp/repository/SurveyRepository.kt
+++ b/app/src/main/java/com/example/surveysapp/repository/SurveyRepository.kt
@@ -2,11 +2,10 @@ package com.example.surveysapp.repository
 
 import com.example.surveysapp.api.AuthApiService
 import com.example.surveysapp.entity.BaseEntity
-import com.example.surveysapp.entity.BaseException
 import com.example.surveysapp.entity.SurveyWrapperEntity
+import com.example.surveysapp.entity.result
 import com.example.surveysapp.room.SurveyDao
 import com.example.surveysapp.room.SurveyRoomEntity
-import com.google.gson.Gson
 import javax.inject.Inject
 
 /**
@@ -22,16 +21,11 @@ class SurveyRepository @Inject constructor(
      * @param pageNumber
      * @param pageSize
      */
-    suspend fun getSurveyList(pageNumber: Int? = null, pageSize: Int? = null): BaseEntity<List<SurveyWrapperEntity>> {
-        val response = authApiService.getSurveyList(pageNumber, pageSize)
-
-        return if (response.isSuccessful) {
-            response.body()!!
-        } else {
-            // Convert errorBody to ErrorEntity for shorter access
-            val baseException = Gson().fromJson(response.errorBody()?.string(), BaseException::class.java)
-            BaseEntity(null, baseException.errors?.get(0))
-        }
+    suspend fun getSurveyList(
+        pageNumber: Int? = null,
+        pageSize: Int? = null
+    ): BaseEntity<List<SurveyWrapperEntity>> {
+        return authApiService.getSurveyList(pageNumber, pageSize).result()
     }
 
     /**

--- a/app/src/main/java/com/example/surveysapp/request/ForgotPasswordRequest.kt
+++ b/app/src/main/java/com/example/surveysapp/request/ForgotPasswordRequest.kt
@@ -1,0 +1,18 @@
+package com.example.surveysapp.request
+
+import com.example.surveysapp.other.ApiKey
+import com.google.gson.annotations.SerializedName
+
+/**
+ * @author longtran
+ * @since 20/06/2021
+ */
+data class ForgotPasswordRequest(
+    @SerializedName(ApiKey.USER)
+    val user: UserRequest,
+) : NonAuthRequest()
+
+data class UserRequest(
+    @SerializedName(ApiKey.EMAIL)
+    val email: String,
+)

--- a/app/src/main/java/com/example/surveysapp/request/LoginRequest.kt
+++ b/app/src/main/java/com/example/surveysapp/request/LoginRequest.kt
@@ -1,0 +1,17 @@
+package com.example.surveysapp.request
+
+import com.example.surveysapp.other.ApiKey
+import com.google.gson.annotations.SerializedName
+
+/**
+ * @author longtran
+ * @since 20/06/2021
+ */
+data class LoginRequest(
+    @SerializedName(ApiKey.EMAIL)
+    val email: String,
+    @SerializedName(ApiKey.PASSWORD)
+    val password: String,
+    @SerializedName(ApiKey.GRANT_TYPE)
+    val grantType: String = "password"
+) : NonAuthRequest()

--- a/app/src/main/java/com/example/surveysapp/request/LogoutRequest.kt
+++ b/app/src/main/java/com/example/surveysapp/request/LogoutRequest.kt
@@ -1,0 +1,13 @@
+package com.example.surveysapp.request
+
+import com.example.surveysapp.other.ApiKey
+import com.google.gson.annotations.SerializedName
+
+/**
+ * @author longtran
+ * @since 20/06/2021
+ */
+data class LogoutRequest(
+    @SerializedName(ApiKey.TOKEN)
+    val accessToken: String
+) : NonAuthRequest()

--- a/app/src/main/java/com/example/surveysapp/request/NonAuthRequest.kt
+++ b/app/src/main/java/com/example/surveysapp/request/NonAuthRequest.kt
@@ -1,0 +1,16 @@
+package com.example.surveysapp.request
+
+import com.example.surveysapp.BuildConfig
+import com.example.surveysapp.other.ApiKey
+import com.google.gson.annotations.SerializedName
+
+/**
+ * @author longtran
+ * @since 20/06/2021
+ */
+open class NonAuthRequest(
+    @SerializedName(ApiKey.CLIENT_ID)
+    val clientId: String? = BuildConfig.client_id,
+    @SerializedName(ApiKey.CLIENT_SECRET)
+    val clientSecret: String? = BuildConfig.client_secret
+)

--- a/app/src/main/java/com/example/surveysapp/request/RefreshTokenRequest.kt
+++ b/app/src/main/java/com/example/surveysapp/request/RefreshTokenRequest.kt
@@ -1,0 +1,15 @@
+package com.example.surveysapp.request
+
+import com.example.surveysapp.other.ApiKey
+import com.google.gson.annotations.SerializedName
+
+/**
+ * @author longtran
+ * @since 20/06/2021
+ */
+data class RefreshTokenRequest(
+    @SerializedName(ApiKey.REFRESH_TOKEN)
+    val refreshToken: String,
+    @SerializedName(ApiKey.GRANT_TYPE)
+    val grantType: String = "refresh_token"
+) : NonAuthRequest()


### PR DESCRIPTION
#9 

## **What happened 👀**

- Duplicated mapping success and error handling on `AuthRepository`
- Using inconsistency param annotations for API request: `@FormUrlEncoded` with `@Field` and `@Body`
- `Authorization` is attached to the header on every request with an empty value

## **Insight 📝**

- Created extensions to mapping response
- Replaced all `@Field` by `@Body` and created request wrapper classes
- This was solve in PR #16 